### PR TITLE
configure repo to test fork PRs

### DIFF
--- a/.github/workflows/publish-galaxy.yml
+++ b/.github/workflows/publish-galaxy.yml
@@ -20,25 +20,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build and publish
-        shell: bash
-        run: |
-          # Ensure ref name looks like semver
-          ref_name="${{ github.ref_name }}"
-          if [[ ! "$ref_name" =~ ^v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-            echo "Ref name '${ref_name}' is not of the form 'vX.Y.Z'"
-            exit 1
-          fi
-
-          # Ensure version nonempty
-          version="${BASH_REMATCH[1]}"
-          if [[ -z "$version" ]]; then
-            echo "Empty version '${version}'"
-            exit 1
-          fi
-
-          # Build the Collection tarball
-          ansible-galaxy collection build
-
-          # Publish the Collection
-          ansible-galaxy collection publish digitalocean-cloud-${version}.tar.gz \
-            --token ${{ secrets.GALAXY_TOKEN }}
+        uses: artis3n/ansible_galaxy_collection@v2
+        with:
+          api_key: '${{ secrets.GALAXY_TOKEN }}'

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -1,10 +1,12 @@
 name: Pull request integration tests
 
 on:
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
     paths:
-      - plugins/module_utils/**
-      - plugins/modules/**
+      - 'plugins/module_utils/**'
+      - 'plugins/modules/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -16,6 +18,8 @@ env:
 jobs:
   test-integration:
     runs-on: ubuntu-22.04
+    # MUST keep this environment set if using pull_request_target
+    environment: integration
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -72,6 +76,11 @@ jobs:
       - name: Perform integration testing
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
+          # MUST set 'git-checkout-ref' if using pull_request_target
+          # MUST use an Environment if using pull_request_target
+          # 'github.event.pull_request.head.sha' checks out the
+          # PR source repo's code, which should be considered untrusted
+          git-checkout-ref: ${{ github.event.pull_request.head.sha }}
           pre-test-cmd: >-
             DIGITALOCEAN_TOKEN=${{ secrets.DIGITALOCEAN_TOKEN }}
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ test-sanity: collection-cleanup collection-prep
 
 # Make a copy of the collection available in an expected Ansible path
 # For running tooling in Codespaces or other environments
+# If you get ansible-lint errors about unresolved modules in this collection,
+# run this command then re-run ansible-lint.
 .PHONY: collection-prep
 collection-prep:
 	mkdir -p ~/.ansible/collections/ansible_collections/digitalocean/cloud

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 
 .PHONY: lint
 lint: collection-prep
-	poetry run ansible-lint --profile=production
+	-poetry run ansible-lint
 	make collection-cleanup
 
 # Assumes ansible-test is available in the global scope, such as within the devcontainer environment

--- a/changelogs/fragments/36-run-integration-on-fork-prs.yaml
+++ b/changelogs/fragments/36-run-integration-on-fork-prs.yaml
@@ -1,0 +1,2 @@
+trivial:
+  - reconfigure CI integration tests to run from fork PRs, allowing external contributions to be tested

--- a/changelogs/fragments/36-run-integration-on-fork-prs.yaml
+++ b/changelogs/fragments/36-run-integration-on-fork-prs.yaml
@@ -1,2 +1,2 @@
 trivial:
-  - reconfigure CI integration tests to run from fork PRs, allowing external contributions to be tested
+  - ci - reconfigure CI integration tests to run from fork PRs, allowing external contributions to be tested (https://github.com/digitalocean/ansible-collection/pull/36). 


### PR DESCRIPTION
Ansible-lint in the pre-commit checks does not like the repo currently. In a separate PR, will go through and clean things up while ensuring ansible-lint runs as a CI check.

![image](https://github.com/digitalocean/ansible-collection/assets/6969296/21bbdab6-f7e6-4e03-be03-02a86c744497)

This PR enables integration tests to run against fork PR contributions. This dangerously checks out the fork PR's code and runs it under the source repo's context, enabling us to use our secrets against the changes in the PR's code. To make that safe, we gate access to secrets inside a GitHub Environment and require manual signoff before deploying any integration test workflow to that Environment. We should manually review PR changes, ensure nothing malicious is included, then approve an Environment deployment. This will pollute PRs with a ton of "deployment" metadata for each matrixes job that deploys to the Environment, but we have to live with it.

The way `pull_request_target` works: it runs the GHA workflow file in the base branch against the changed code in the contribution PR. Therefore, changes _to the `pull_request_target` workflow file itself_ will not be tested inside PRs, but instead only once that code is merged to the main branch and a subsequent PR is made. This is a side effect we have to live with. In the past, I've temporarily added `pull_request` to the workflow file if I'm testing changes to a file, to ensure it works, then remove `pull_request` before merging.

Closes #19.