### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,24 @@ DigitalOcean Collection Release Notes
 .. contents:: Topics
 
 
+v0.4.0
+======
+
+Bugfixes
+--------
+
+- database_cluster - fix C(database_cluster) module and reenable integration test (https://github.com/digitalocean/ansible-collection/pull/60).
+- kubernetes_cluster - fix C(kubernetes_cluster) module polling and refactor integration test (https://github.com/digitalocean/ansible-collection/issues/62).
+- project - fix C(project) module with API workaround and add integration test (https://github.com/digitalocean/ansible-collection/pull/61).
+
+New Plugins
+-----------
+
+Inventory
+~~~~~~~~~
+
+- droplets - Droplets dynamic inventory plugin
+
 v0.3.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -218,3 +218,26 @@ releases:
       name: droplet_action_snapshot
       namespace: ''
     release_date: '2023-09-20'
+  0.4.0:
+    changes:
+      bugfixes:
+      - database_cluster - fix C(database_cluster) module and reenable integration
+        test (https://github.com/digitalocean/ansible-collection/pull/60).
+      - kubernetes_cluster - fix C(kubernetes_cluster) module polling and refactor
+        integration test (https://github.com/digitalocean/ansible-collection/issues/62).
+      - project - fix C(project) module with API workaround and add integration test
+        (https://github.com/digitalocean/ansible-collection/pull/61).
+    fragments:
+    - 58-publish-galaxy.yaml
+    - 59-readme-badges.yaml
+    - 60-fix-database-cluster.yaml
+    - 61-fix-project.yaml
+    - 62-fix-kubernetes-cluster.yaml
+    - 66-database-cluster-timeout.yaml
+    - 71-dependabot-bumps.yaml
+    plugins:
+      inventory:
+      - description: Droplets dynamic inventory plugin
+        name: droplets
+        namespace: null
+    release_date: '2023-09-25'

--- a/changelogs/fragments/58-publish-galaxy.yaml
+++ b/changelogs/fragments/58-publish-galaxy.yaml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - publish to Galaxy based when GitHub Release is published (https://github.com/digitalocean/ansible-collection/pull/58).

--- a/changelogs/fragments/59-readme-badges.yaml
+++ b/changelogs/fragments/59-readme-badges.yaml
@@ -1,2 +1,0 @@
-trivial:
-  - docs - add ansible and OpenSSF badges to the readme (https://github.com/digitalocean/ansible-collection/pull/59).

--- a/changelogs/fragments/60-fix-database-cluster.yaml
+++ b/changelogs/fragments/60-fix-database-cluster.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - database_cluster - fix C(database_cluster) module and reenable integration test (https://github.com/digitalocean/ansible-collection/pull/60).

--- a/changelogs/fragments/61-fix-project.yaml
+++ b/changelogs/fragments/61-fix-project.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - project - fix C(project) module with API workaround and add integration test (https://github.com/digitalocean/ansible-collection/pull/61).

--- a/changelogs/fragments/62-fix-kubernetes-cluster.yaml
+++ b/changelogs/fragments/62-fix-kubernetes-cluster.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - kubernetes_cluster - fix C(kubernetes_cluster) module polling and refactor integration test (https://github.com/digitalocean/ansible-collection/issues/62).

--- a/changelogs/fragments/66-database-cluster-timeout.yaml
+++ b/changelogs/fragments/66-database-cluster-timeout.yaml
@@ -1,2 +1,0 @@
-trivial:
-  - database_cluster - double C(database_cluster) integration testing timeout (https://github.com/digitalocean/ansible-collection/issues/66).

--- a/changelogs/fragments/71-dependabot-bumps.yaml
+++ b/changelogs/fragments/71-dependabot-bumps.yaml
@@ -1,2 +1,0 @@
-trivial:
-  - dependabot - bump C(setuptools), C(boto3), and C(pylint) (https://github.com/digitalocean/ansible-collection/issues/71).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 # See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 namespace: digitalocean
 name: cloud
-version: 0.3.0
+version: 0.4.0
 readme: README.md
 authors:
   - Mark Mercado (@mamercad)


### PR DESCRIPTION
Bugfixes
--------

- database_cluster - fix C(database_cluster) module and reenable integration test (https://github.com/digitalocean/ansible-collection/pull/60).
- kubernetes_cluster - fix C(kubernetes_cluster) module polling and refactor integration test (https://github.com/digitalocean/ansible-collection/issues/62).
- project - fix C(project) module with API workaround and add integration test (https://github.com/digitalocean/ansible-collection/pull/61).

New Plugins
-----------

Inventory
---------

- droplets - Droplets dynamic inventory plugin