### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       interval: "weekly"
     labels:
       - "dependabot"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -16,3 +20,8 @@ updates:
       interval: "weekly"
     labels:
       - "dependabot"
+    groups:
+      production-dependencies:
+        dependency-type: production
+      nonprod-dependencies:
+        dependency-type: development

--- a/changelogs/fragments/84-grouped-dependabot.yml
+++ b/changelogs/fragments/84-grouped-dependabot.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ci - configure dependabot for grouped dependency updates (https://github.com/digitalocean/ansible-collection/pull/84).


### PR DESCRIPTION
I think I did this right, not sure: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

Goal is to update all GitHub Actions at once, and to update `tool.poetry.dependencies` together and `tool.poetry.group.dev.dependencies` separately from 'prod' python devs, but themselves together in a PR.