### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ DigitalOcean Collection Release Notes
 .. contents:: Topics
 
 
+v0.5.1
+======
+
+Trivial Changes
+---------------
+
+- docs - fix broken links due to Ansible Galaxy NG launch (https://github.com/digitalocean/ansible-collection/pull/91).
+- tests - bump Kubernetes version in its integration test (https://github.com/digitalocean/ansible-collection/issues/100).
+- lint - tweaked ansible-lint configuration so production profile is now the target for this repo (https://github.com/digitalocean/ansible-collection/pull/104).
+
 v0.5.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -275,3 +275,10 @@ releases:
       name: uptime_checks_state_info
       namespace: ''
     release_date: '2023-10-12'
+  0.5.1:
+    changes: {}
+    fragments:
+    - 100-bump-kubernetes-version.yml
+    - 104-ansible-lint.yml
+    - 91-ansible-galaxy-ng.yml
+    release_date: '2023-12-21'

--- a/changelogs/fragments/100-bump-kubernetes-version.yml
+++ b/changelogs/fragments/100-bump-kubernetes-version.yml
@@ -1,2 +1,0 @@
-trivial:
-  - tests - bump Kubernetes version in its integration test (https://github.com/digitalocean/ansible-collection/issues/100).

--- a/changelogs/fragments/104-ansible-lint.yml
+++ b/changelogs/fragments/104-ansible-lint.yml
@@ -1,2 +1,0 @@
-trivial:
-  - lint - tweaked ansible-lint configuration so production profile is now the target for this repo (https://github.com/digitalocean/ansible-collection/pull/104).

--- a/changelogs/fragments/91-ansible-galaxy-ng.yml
+++ b/changelogs/fragments/91-ansible-galaxy-ng.yml
@@ -1,2 +1,0 @@
-trivial:
-  - docs - fix broken links due to Ansible Galaxy NG launch (https://github.com/digitalocean/ansible-collection/pull/91).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 # See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 namespace: digitalocean
 name: cloud
-version: "0.5.0"
+version: "0.5.1"
 readme: README.md
 authors:
   - Mark Mercado (@mamercad)


### PR DESCRIPTION
Trivial Changes
---------------

- docs - fix broken links due to Ansible Galaxy NG launch (https://github.com/digitalocean/ansible-collection/pull/91).
- tests - bump Kubernetes version in its integration test (https://github.com/digitalocean/ansible-collection/issues/100).
- lint - tweaked ansible-lint configuration so production profile is now the target for this repo (https://github.com/digitalocean/ansible-collection/pull/104).