### PR TITLE
fix: run https://github.com/crate-ci/typos --write-changes to fix up typos

### DIFF
--- a/plugins/modules/cdn_endpoints.py
+++ b/plugins/modules/cdn_endpoints.py
@@ -191,7 +191,7 @@ class CDNEndpoints(DigitalOceanCommonModule):
                         )
                     self.module.exit_json(changed=False, endpoint=existing_cdn)
                 self.module.fail_json(
-                    changed=False, msg=error.get("Message"), error=error, endpiont=[]
+                    changed=False, msg=error.get("Message"), error=error, endpoint=[]
                 )
 
         try:

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -73,11 +73,13 @@ EXAMPLES = r"""
       MIIJQwIBADANBgkqhkiG9w0BAQEFAASCCS0wggkpAgEAAoICAQDE39Eyyp2QJIp6
       IvXELS4L+Wa8dAM4Uk0enV3PJKm2a674Ys0WSle2dzsd1EfpRXMNTt+iPZCyZQIS
       ...
+      -----END PRIVATE KEY-----
     leaf_certificate: |
       -----BEGIN CERTIFICATE-----
       MIIF8jCCA9oCCQDHvZvzJneVuzANBgkqhkiG9w0BAQsFADCBujELMAkGA1UEBhMC
       VVMxETAPBgNVBAgMCE1pY2hpZ2FuMRQwEgYDVQQHDAtHcmFuZCBCbGFuYzETMBEG
       ...
+      -----END CERTIFICATE-----
 
 - name: Create Let's Encrypt certificate
   digitalocean.cloud.certificate:

--- a/plugins/modules/monitoring_alert_policy.py
+++ b/plugins/modules/monitoring_alert_policy.py
@@ -34,7 +34,7 @@ options:
     required: true
   compare:
     description:
-      - Comparision.
+      - Comparison.
     type: str
     required: true
     choices: ["GreaterThan", "LessThan"]
@@ -246,7 +246,7 @@ class MonitoringAlertPolicy(DigitalOceanCommonModule):
             body = {
                 "alerts": self.alerts,
                 "compare": self.compare,
-                "desciption": self.description,
+                "description": self.description,
                 "enabled": self.enabled,
                 "entities": self.entities,
                 "tags": self.tags,

--- a/plugins/modules/volume_action.py
+++ b/plugins/modules/volume_action.py
@@ -132,7 +132,7 @@ msg:
     - Attached volume test-vol in nyc3 to test-droplet
     - Volume test-vol in nyc3 not attached to test-droplet
     - Detached volume test-vol in nyc3 from test-droplet
-    - Volume test-vol in nyc3 would be attahed to test-droplet
+    - Volume test-vol in nyc3 would be attached to test-droplet
     - Volume test-vol in nyc3 would be detached from test-droplet
 """
 


### PR DESCRIPTION
at time of writing:
```
$ cat _typos.toml
[files]
extend-exclude = [
  "*.svg",
  "*.json",
  "*.sh",
]

[default.extend-identifiers]
"b6fr89dbf6d9156cace5f3c78dc9851d957381ef" = "b6fr89dbf6d9156cace5f3c78dc9851d957381ef"

[default]
extend-ignore-re = [
  "(?Rms)\\s*-----BEGIN CERTIFICATE-----(.*)-----END CERTIFICATE-----\\s*",
  "(?
```