### PR TITLE
Create Release v1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,25 @@ DigitalOcean Collection Release Notes
 
 .. contents:: Topics
 
+v1.0.0
+======
+
+Release Summary
+---------------
+
+Bump Python, project-wide, to 3.11.11. Fix ``state: absent`` bug in the Droplet module. Disable integration testing for the ``monitoring_alert_policy`` and ``one_click`` modules since they are broken (https://github.com/digitalocean/ansible-collection/pull/234).
+
+Minor Changes
+-------------
+
+- Bump Python to 3.11.11 and Poetry to 1.8.5 (https://github.com/digitalocean/ansible-collection/issues/229).
+- monitoring_alert_policy - mark integration test as ``disabled`` since it is broken (https://github.com/digitalocean/ansible-collection/issues/229)."
+- one_click - mark this integration test as ``disabled`` since it is broken (https://github.com/digitalocean/ansible-collection/issues/229)."
+
+Bugfixes
+--------
+
+- droplet - add misisng ``droplet_id`` parameter when for ``state: absent`` (https://github.com/digitalocean/ansible-collection/issues/229).
 
 v0.6.0
 ======
@@ -15,13 +34,6 @@ Minor Changes
 
 v0.5.1
 ======
-
-Trivial Changes
----------------
-
-- docs - fix broken links due to Ansible Galaxy NG launch (https://github.com/digitalocean/ansible-collection/pull/91).
-- tests - bump Kubernetes version in its integration test (https://github.com/digitalocean/ansible-collection/issues/100).
-- lint - tweaked ansible-lint configuration so production profile is now the target for this repo (https://github.com/digitalocean/ansible-collection/pull/104).
 
 v0.5.0
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -276,7 +276,6 @@ releases:
       namespace: ''
     release_date: '2023-10-12'
   0.5.1:
-    changes: {}
     fragments:
     - 100-bump-kubernetes-version.yml
     - 104-ansible-lint.yml
@@ -295,3 +294,22 @@ releases:
     - 147-integration-testing-kubernetes-version.yml
     - 180-add-action_groups.yml
     release_date: '2024-05-23'
+  1.0.0:
+    changes:
+      bugfixes:
+      - 'droplet - add misisng ``droplet_id`` parameter when for ``state: absent``
+        (https://github.com/digitalocean/ansible-collection/issues/229).'
+      minor_changes:
+      - Bump Python to 3.11.11 and Poetry to 1.8.5 (https://github.com/digitalocean/ansible-collection/issues/229).
+      - monitoring_alert_policy - mark integration test as ``disabled`` since it is
+        broken (https://github.com/digitalocean/ansible-collection/issues/229)."
+      - one_click - mark this integration test as ``disabled`` since it is broken
+        (https://github.com/digitalocean/ansible-collection/issues/229)."
+      release_summary: 'Bump Python, project-wide, to 3.11.11. Fix ``state: absent``
+        bug in the Droplet module. Disable integration testing for the ``monitoring_alert_policy``
+        and ``one_click`` modules since they are broken (https://github.com/digitalocean/ansible-collection/pull/234).'
+    fragments:
+    - 229-bump-python-311.yaml
+    - 229-disable-monitoring-alert-policy-and-one-click-int-tests.yml
+    - 229-droplet-id-absent.yaml
+    release_date: '2025-03-06'

--- a/changelogs/fragments/229-bump-python-311.yaml
+++ b/changelogs/fragments/229-bump-python-311.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "Bump Python to 3.11.11 and Poetry to 1.8.5 (https://github.com/digitalocean/ansible-collection/issues/229)."

--- a/changelogs/fragments/229-disable-monitoring-alert-policy-and-one-click-int-tests.yml
+++ b/changelogs/fragments/229-disable-monitoring-alert-policy-and-one-click-int-tests.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - monitoring_alert_policy - mark integration test as ``disabled`` since it is broken (https://github.com/digitalocean/ansible-collection/issues/229)."
-  - one_click - mark this integration test as ``disabled`` since it is broken (https://github.com/digitalocean/ansible-collection/issues/229)."

--- a/changelogs/fragments/229-droplet-id-absent.yaml
+++ b/changelogs/fragments/229-droplet-id-absent.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - "droplet - add misisng ``droplet_id`` parameter when for ``state: absent`` (https://github.com/digitalocean/ansible-collection/issues/229)."


### PR DESCRIPTION
v1.0.0
======

Release Summary
---------------

Bump Python, project-wide, to 3.11.11. Fix ``state: absent`` bug in the Droplet module. Disable integration testing for the ``monitoring_alert_policy`` and ``one_click`` modules since they are broken (https://github.com/digitalocean/ansible-collection/pull/234).

Minor Changes
-------------

- Bump Python to 3.11.11 and Poetry to 1.8.5 (https://github.com/digitalocean/ansible-collection/issues/229).
- monitoring_alert_policy - mark integration test as ``disabled`` since it is broken (https://github.com/digitalocean/ansible-collection/issues/229)."
- one_click - mark this integration test as ``disabled`` since it is broken (https://github.com/digitalocean/ansible-collection/issues/229)."

Bugfixes
--------

- droplet - add misisng ``droplet_id`` parameter when for ``state: absent`` (https://github.com/digitalocean/ansible-collection/issues/229).